### PR TITLE
chore: update node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,5 +42,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Update action to use node20 because of the new versions of Github Actions runnners